### PR TITLE
Show Chat Update time  if last message time doesn't exist

### DIFF
--- a/frontend/src/components/Chat/Chats.jsx
+++ b/frontend/src/components/Chat/Chats.jsx
@@ -128,7 +128,10 @@ const ChatsComponent = ({onChatSelect}) => {
                         <span>{chat.first_name_recipient} {chat.last_name_recipient}</span>
                         <MessageAndTime>
                             <MessageContent>{chat.latest_message_content}</MessageContent>
-                            <MessageTime>{formatMessageDate(chat.latest_message_time)}</MessageTime>
+
+                            {/* check if chat.latest_message_time is not empty  else we shout chat.updated_at*/}
+                            <MessageTime>{formatMessageDate(chat.latest_message_time || chat.updated_at)}</MessageTime>
+
                         </MessageAndTime>
                     </UserChatInfo>
                 </UserChat>


### PR DESCRIPTION
Some chats are created but the user didn't send a message. So we can't show the last message time in the chats. 
There 2 things for this : 
- Wither we delete the chats after a certain period since no message was sent 
- We just show when the chat was updated instead of the last message time. 

Implemented Solution : 
For now let's just show the chat update time instead. We can think of something else next time 